### PR TITLE
feat: add server.js for deploying dashboard

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -1,0 +1,28 @@
+// include dependencies
+const express = require('express')
+const path = require('path')
+const { createProxyMiddleware } = require('http-proxy-middleware')
+const app = express()
+
+// proxy middleware options
+const options = {
+  target: 'http://95.179.130.39:5000', // target host
+  changeOrigin: true, // needed for virtual hosted sites
+  pathRewrite: {
+    '^/api/': '/', // remove base path
+  },
+}
+
+// create the proxy (without context)
+const exampleProxy = createProxyMiddleware(options)
+app.use('/api', exampleProxy)
+
+// app.use(express.static(path.join(__dirname, 'public')))
+app.use(express.static(path.join(__dirname, '..', 'build')))
+
+app.get('/*', function (req, res) {
+  res.sendFile(path.join(__dirname, '..', 'build', 'index.html'))
+})
+
+// mount `exampleProxy` in web server
+app.listen(3000)

--- a/src/pages/Leaderboard/Leaderboard.tsx
+++ b/src/pages/Leaderboard/Leaderboard.tsx
@@ -15,7 +15,7 @@ import Paper from '@material-ui/core/Paper'
 import MenuItem from '@material-ui/core/MenuItem'
 import FormControl from '@material-ui/core/FormControl'
 import Select from '@material-ui/core/Select'
-import axios from 'axios'
+import { api as axios } from '../../services'
 import CircularProgress from '@material-ui/core/CircularProgress'
 
 const headCells = [
@@ -287,10 +287,12 @@ const Leaderboard = () => {
             <EnhancedTableHead />
             {loading ? (
               <div style={{ height: '530px' }}></div>
+            ) : error || !leaderboardData?.leaderboard ? (
+              <p>Error</p>
             ) : (
               <TableBody>
-                {leaderboardData.leaderboard
-                  .slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
+                {leaderboardData?.leaderboard
+                  ?.slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
                   .map((row, index) => {
                     const labelId = `enhanced-table-checkbox-${index}`
 

--- a/src/pages/User/UserSearch.tsx
+++ b/src/pages/User/UserSearch.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react'
 import Container from '@material-ui/core/Container'
 import { useHistory } from 'react-router'
-import axios from 'axios'
+import { api as axios } from '../../services'
 import TextField from '@material-ui/core/TextField'
 import SearchIcon from '@material-ui/icons/Search'
 import IconButton from '@material-ui/core/IconButton'

--- a/src/pages/User/UserStats.tsx
+++ b/src/pages/User/UserStats.tsx
@@ -23,7 +23,7 @@ import {
   LabelList,
   ResponsiveContainer,
 } from 'recharts'
-import axios from 'axios'
+import { api as axios } from '../../services'
 
 import CustomTooltipContent from '../../components/CustomTooltipContent'
 

--- a/src/services/api.tsx
+++ b/src/services/api.tsx
@@ -1,0 +1,7 @@
+import axios from 'axios'
+
+const axiosInstance = axios.create({
+  baseURL: '/api/',
+})
+
+export default axiosInstance

--- a/src/services/index.tsx
+++ b/src/services/index.tsx
@@ -1,0 +1,1 @@
+export { default as api } from './api'


### PR DESCRIPTION
Using express when dev deploying is better than `npm run start` which uses a ton of cpu and memory.